### PR TITLE
global: fallback to pyfs for non-xrootd paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,6 @@
 Changes
 =======
 
-Version 1.0.0a1 (released 2016-08-19)
+Version 1.0.0a2 (released 2016-09-05)
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 =========================
- Invenio-XRootD v1.0.0a1
+ Invenio-XRootD v1.0.0a2
 =========================
 
-Invenio-XRootD v1.0.0a1 was released on August 19, 2016.
+Invenio-XRootD v1.0.0a2 was released on September 5, 2016.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-xrootd==1.0.0a1
+   $ pip install invenio-xrootd==1.0.0a2
 
 Documentation
 -------------

--- a/invenio_xrootd/version.py
+++ b/invenio_xrootd/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a2.dev20160819"
+__version__ = "1.0.0a2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,12 @@ def xrd_storage(file_url):
 
 
 @pytest.fixture
+def xrd_storage_ospath(file_path):
+    """Storage instance for XRootDFileStorage with OS path."""
+    return XRootDFileStorage(file_path)
+
+
+@pytest.fixture
 def xrd_storage_mocked(file_url, file_md5):
     """Patch xrd_checksum."""
     # Since local xrootd server can't compute checksums.

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -87,6 +87,13 @@ def test_get_fs(xrd_storage, file_path, file_url):
     assert exists(file_path)
 
 
+def test_get_fs_ospath(xrd_storage_ospath, file_path):
+    """Test checksum overwrite."""
+    assert not exists(file_path)
+    xrd_storage_ospath.initialize(10)
+    assert exists(file_path)
+
+
 def test_eos_initialize(eos_storage, file_path, file_url):
     """Test checksum overwrite."""
     assert not exists(file_path)


### PR DESCRIPTION
Signed-off-by: Krzysztof Nowak k.nowak@cern.ch
