### PR TITLE
storage: allow default checksum implementation

### DIFF
--- a/invenio_xrootd/storage.py
+++ b/invenio_xrootd/storage.py
@@ -73,13 +73,19 @@ class XRootDFileStorage(PyFSFileStorage):
 
         return (fs, filename)
 
-    def checksum(self, chunk_size=None, progress_callback=None):
+    def checksum(self, chunk_size=None, progress_callback=None,
+                 use_default_impl=False):
         """Compute checksum of file.
 
         Queries the XRootD server to get checksum if possible, otherwise falls
         back to default Python implementation. The checksum algorithm used
         will be the one configured on the XRootD server.
         """
+        if use_default_impl:
+            return super(XRootDFileStorage, self).checksum(
+                chunk_size=chunk_size,
+                progress_callback=progress_callback,
+            )
         try:
             fs, path = self._get_fs()
             if not hasattr(fs, 'xrd_checksum'):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -73,6 +73,8 @@ def test_checksum_fallback(xrd_storage, eos_storage, file_md5):
 def test_checksum_xrd(xrd_storage_mocked, file_md5):
     """Test checksum."""
     assert xrd_storage_mocked.checksum() == 'adler32:{0}'.format(file_md5)
+    assert xrd_storage_mocked.checksum(
+        use_default_impl=True) == 'md5:{0}'.format(file_md5)
 
 
 def test_checksum_xrd_overwrite(app, xrd_storage_mocked, file_md5):


### PR DESCRIPTION
* Adds an optional parameter to `XRootDFileStorage.checksum` for
  forcing execution of the default checksum implementation.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>